### PR TITLE
Fix for Next.js localstorage error

### DIFF
--- a/locales/locale.js
+++ b/locales/locale.js
@@ -28,7 +28,7 @@ i18n
   // for all options read: https://www.i18next.com/overview/configuration-options
   .init({
     resources,
-    lng: localStorage.getItem('i18nextLng'),
+    lng: localStorage  ? localStorage.getItem('i18nextLng'): 'en',
     ns: ["common"],
     defaultNS: "common",
     fallbackNS: "common",

--- a/src/Scheduler.jsx
+++ b/src/Scheduler.jsx
@@ -474,7 +474,7 @@ function Scheduler(props) {
   ])
 
   useEffect(() => {
-    if (locale !== i18n.language) { //localStorage.getItem('i18nextLng')
+    if (locale !== i18n.language && localStorage) { //localStorage.getItem('i18nextLng')
       localStorage.setItem('i18nextLng', locale.toLowerCase())
       i18n.changeLanguage(locale.toLowerCase())
       updateWeekDays()


### PR DESCRIPTION
Fix for next.js localstorage is not available on the server and will throw the error below and cause issues. This is safe check to bypass the error and allow this package to be used with Next.js.

- error node_modules/react-mui-scheduler/dist/index.esm.js (285:0) @ eval
- error ReferenceError: localStorage is not defined